### PR TITLE
Fix getFilename()

### DIFF
--- a/src/ShopSys/PhpStormInspect/ProblemFactory.php
+++ b/src/ShopSys/PhpStormInspect/ProblemFactory.php
@@ -42,7 +42,9 @@ class ProblemFactory
      */
     private function getFilename($projectPath, SimpleXMLElement $problemXml)
     {
-        $filename = str_replace('file://$PROJECT_DIR$/', $projectPath . '/', (string)$problemXml->file);
+        $filename = (string)$problemXml->file;
+        $filename = preg_replace('#^file://#', '', $filename);
+        $filename = str_replace('$PROJECT_DIR$', $projectPath, $filename);
 
         return realpath($filename);
     }


### PR DESCRIPTION
In my case, the xml files generated by phpstorm haven't `$PROJECT_DIR$`, they are as full path.

So the replace isn't done and the `realpath()` fails because of `file://` protocol.

The change ensures that this case will work.

Note: you can ensure that it will work always by changing the return by

```php
return realpath($filename) ?: $filename;
```